### PR TITLE
Improving mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## [0.4.0]
+
+### Added
+
+- mixins: splitting in coherent mixins and adding tests (#7)
+
+### Changed
+
+- fix: url_path for revert action from `aaaa/<version_pk>` to `revert/<version_pk>` (#4)
+
+
 ## [0.3.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@ you should add `'reversion.middleware.RevisionMiddleware'` to your `MIDDLEWARE` 
 
 The `HistoryModelViewSet` extends django-rest-framework's `ModelViewSet` adding
 
-- a GET `history` action in the detail
+- a GET `history` action in the detail (`/my-model-url/<pk>/history/`)
 
     displaying a list of all revisions of that specific record
 
-- a GET `deleted` action in the list
+- a GET `deleted` action in the list (`/my-model-url/deleted/`)
 
     displaying a list of all deleted records
+
+- a POST `revert` action in the detail (`/my-model-url/<pk>/revert/<version_pk>/`)
+
+    allowing users to revert to a previous revision of the object
 
 You can use the `HistoryModelViewSet` in place of the `ModelViewSet`
 during viewsets definition.
@@ -35,11 +39,15 @@ class MyModelViewSet(HistoryModelViewSet):
     # ...
 ```
 
-Then if your endpoint exposes on the url `/my-models/` you can get
+For advanced or selective implementation, you can use `reversion_rest_framework.mixins`.
 
-- the history of a record using `my-models/<pk>/history/`
+- `HistoryOnlyMixin` contains only the `history` action
 
-- all deleted records (ordered by date_created descending) using `my-models/deleted/`
+- `DeletedOnlyMixin` contains only the `deleted` action
+
+- `ReadOnlyHistoryModel` contains `history` and `revert` actions
+
+- `RevertMixin` contains `history`, `revert` and `deleted` actions
 
 
 ### Customizing the VersionSerializer

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-reversion-rest-framework
-version = 0.3.1
+version = 0.4.0
 author = Denny Biasiolli
 author_email = denny.biasiolli@gmail.com
 description = A package for adding a django-reversion history endpoint to django-rest-framework ModelViewSet

--- a/tests/test_app/tests/test_mixins.py
+++ b/tests/test_app/tests/test_mixins.py
@@ -1,0 +1,103 @@
+from django.test.testcases import TestCase
+from rest_framework.viewsets import GenericViewSet
+from reversion_rest_framework import mixins
+from reversion_rest_framework.serializers import VersionSerializer
+
+
+class MixinsTests(TestCase):
+    def test_base_history_model_mixin(self):
+        """
+        Ensure we don't have actions but only version_serializer
+        """
+        class TestViewSet(mixins.BaseHistoryModelMixin, GenericViewSet):
+            pass
+
+        url_paths = list(
+            action.url_path for action in TestViewSet.get_extra_actions()
+        )
+        self.assertEqual(len(url_paths), 0)
+        self.assertEqual(TestViewSet.version_serializer, VersionSerializer)
+
+    def test_history_only_mixin(self):
+        """
+        Ensure we have only the history action
+        """
+        class TestViewSet(mixins.HistoryOnlyMixin, GenericViewSet):
+            pass
+
+        url_paths = list(
+            action.url_path for action in TestViewSet.get_extra_actions()
+        )
+        self.assertTrue(
+            issubclass(mixins.HistoryOnlyMixin, mixins.BaseHistoryModelMixin))
+        self.assertEqual(len(url_paths), 1)
+        self.assertTrue('history' in url_paths)
+
+    def test_deleted_only_mixin(self):
+        """
+        Ensure we have only the deleted action
+        """
+        class TestViewSet(mixins.DeletedOnlyMixin, GenericViewSet):
+            pass
+
+        url_paths = list(
+            action.url_path for action in TestViewSet.get_extra_actions()
+        )
+        self.assertTrue(
+            issubclass(mixins.DeletedOnlyMixin, mixins.BaseHistoryModelMixin))
+        self.assertIsNone(TestViewSet.version_model)
+        self.assertEqual(len(url_paths), 1)
+        self.assertTrue('deleted' in url_paths)
+
+    def test_read_only_history_model_mixin(self):
+        """
+        Ensure we have history and deleted actions
+        """
+        class TestViewSet(mixins.ReadOnlyHistoryModel, GenericViewSet):
+            pass
+
+        url_paths = list(
+            action.url_path for action in TestViewSet.get_extra_actions()
+        )
+        self.assertTrue(
+            issubclass(mixins.ReadOnlyHistoryModel, mixins.HistoryOnlyMixin))
+        self.assertTrue(
+            issubclass(mixins.ReadOnlyHistoryModel, mixins.DeletedOnlyMixin))
+        self.assertEqual(len(url_paths), 2)
+        self.assertTrue('history' in url_paths)
+        self.assertTrue('deleted' in url_paths)
+
+    def test_revert_mixin(self):
+        """
+        Ensure we have revert action
+        """
+        class TestViewSet(mixins.RevertMixin, GenericViewSet):
+            pass
+
+        url_paths = list(
+            action.url_path for action in TestViewSet.get_extra_actions()
+        )
+        self.assertTrue(
+            issubclass(mixins.RevertMixin, mixins.HistoryOnlyMixin))
+        self.assertEqual(len(url_paths), 2)
+        self.assertTrue('history' in url_paths)
+        self.assertTrue('revert/(?P<version_pk>\d+)' in url_paths)
+
+    def test_history_model_mixin(self):
+        """
+        Ensure we have all actions
+        """
+        class TestViewSet(mixins.HistoryModelMixin, GenericViewSet):
+            pass
+
+        url_paths = list(
+            action.url_path for action in TestViewSet.get_extra_actions()
+        )
+        self.assertTrue(
+            issubclass(mixins.HistoryModelMixin, mixins.RevertMixin))
+        self.assertTrue(
+            issubclass(mixins.HistoryModelMixin, mixins.DeletedOnlyMixin))
+        self.assertEqual(len(url_paths), 3)
+        self.assertTrue('history' in url_paths)
+        self.assertTrue('revert/(?P<version_pk>\d+)' in url_paths)
+        self.assertTrue('deleted' in url_paths)


### PR DESCRIPTION
### Added

- mixins: splitting in coherent mixins and adding tests (#7)

### Changed

- fix: url_path for revert action from `aaaa/<version_pk>` to `revert/<version_pk>` (#4)
