### PR TITLE
support custom parameters defined in urlconf

### DIFF
--- a/src/reversion_rest_framework/mixins.py
+++ b/src/reversion_rest_framework/mixins.py
@@ -68,7 +68,7 @@ class HistoryMixin(BaseHistoryMixin):
         return _VersionsSerializer(queryset, many=many)
 
     @action(detail=True, methods=["GET"], name="Get History")
-    def history(self, request, pk=None):
+    def history(self, request, pk=None, *args, **kwargs):
         instance = self.get_object()
         versions = Version.objects.get_for_object(instance).order_by(
             "-revision__date_created"
@@ -86,7 +86,7 @@ class HistoryMixin(BaseHistoryMixin):
         name="Get Historic Version",
         url_path=r"history/(?P<version_pk>\d+)",
     )
-    def version(self, request, pk=None, version_pk=None):
+    def version(self, request, pk=None, version_pk=None, *args, **kwargs):
         instance = self.get_object()
         version = get_object_or_404(
             Version.objects.get_for_object(instance), id=version_pk
@@ -120,7 +120,7 @@ class DeletedMixin(BaseHistoryMixin):
             return serializer_class.Meta.model
 
     @action(detail=False, methods=["GET"], name="Get Deleted")
-    def deleted(self, request):
+    def deleted(self, request, *args, **kwargs):
         model = self._get_version_model()
         versions = Version.objects.get_deleted(model)
         versions = versions.order_by("-revision__date_created")

--- a/tests/test_app/tests/test_api.py
+++ b/tests/test_app/tests/test_api.py
@@ -482,3 +482,18 @@ class TestLimitedModelViewSetTests(AuthApiTestCase):
         self.assertEqual(response.data[2]["revision"]["user"], 1)
         self.assertIsNotNone(response.data[2]["revision"]["comment"])
         self.assertEqual(response.data[2]["field_dict"]["name"], "Foo 1.2.0")
+
+
+class TestCustomParamUrls(AuthApiTestCase):
+    def setUp(self):
+        super().setUp()
+        self.record1 = TestModel.objects.create(name="test name")
+
+    def test_url_with_extra_params(self):
+        url = reverse("testmodel-history", kwargs={"pk": self.record1.pk})
+        url = url.replace(
+            "/test-app/test-models/",
+            "/test-app/param/bar/test-models/",
+        )
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/test_app/urls.py
+++ b/tests/test_app/urls.py
@@ -29,5 +29,6 @@ router.register(
 # The API URLs are now determined automatically by the router.
 # Additionally, we include the login URLs for the browsable API.
 urlpatterns = [
+    path("param/<foo>/", include(router.urls)),
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
If developer define custom parameters in their urlconf, then `TypeError` shows when they accessing the action API:

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/15968154/202889688-103f786c-30ab-4574-b790-1ca256399088.png">